### PR TITLE
 jazz107 defect 13824

### DIFF
--- a/src/ISO8583/1987/ISO8583_1987.xsd
+++ b/src/ISO8583/1987/ISO8583_1987.xsd
@@ -17,7 +17,7 @@
 	 * © Copyright International Business Machines Corporation, 2015. 
 	 *
 	 ************************************************************************* 
-	 * Version 1.3 ISO8583_1987.xsd
+	 * Version 1.4 ISO8583_1987.xsd
 	 * 
 	 * This DFDL schema is for use with the IIB v10 DFDL ISO8583 tutorial.
 	 *
@@ -238,9 +238,9 @@
                         <xs:restriction base="isotyp:Type_n_decimal"/>
                     </xs:simpleType>
                 </xs:element>
-                <xs:element dfdl:length="10" dfdl:lengthUnits="characters" dfdl:occursCount="{/ISO8583_1987/PrimaryBitmap/Bit007}" ibmDfdlExtn:sampleValue="2001-12-31T23:59:59" minOccurs="0" name="TransmissionDatetime_007">
+                <xs:element dfdl:length="10" dfdl:lengthUnits="characters" dfdl:occursCount="{/ISO8583_1987/PrimaryBitmap/Bit007}" ibmDfdlExtn:sampleValue="1231235959" minOccurs="0" name="TransmissionDatetime_007">
                     <xs:simpleType>
-                        <xs:restriction base="isotyp:Type_n_dateTime"/>
+                        <xs:restriction base="isotyp:Type_n_dateTimeNoYear"/>
                     </xs:simpleType>
                 </xs:element>
                 <xs:element dfdl:length="8" dfdl:lengthUnits="characters" dfdl:occursCount="{/ISO8583_1987/PrimaryBitmap/Bit008}" dfdl:textNumberPattern="+00000000" dfdl:textNumberRep="zoned" ibmDfdlExtn:sampleValue="00000100" minOccurs="0" name="AmountCardHolderBillingFee_008">
@@ -271,27 +271,27 @@
                         <xs:restriction base="isotyp:Type_n_time"/>
                     </xs:simpleType>
                 </xs:element>
-                <xs:element dfdl:length="4" dfdl:lengthUnits="characters" dfdl:occursCount="{/ISO8583_1987/PrimaryBitmap/Bit013}" dfdl:textNumberPadCharacter="0" ibmDfdlExtn:sampleValue="2001-12-31" minOccurs="0" name="DateLocalTransaction_013">
+                <xs:element dfdl:length="4" dfdl:lengthUnits="characters" dfdl:occursCount="{/ISO8583_1987/PrimaryBitmap/Bit013}" dfdl:textNumberPadCharacter="0" ibmDfdlExtn:sampleValue="1231" minOccurs="0" name="DateLocalTransaction_013">
                     <xs:simpleType>
                         <xs:restriction base="isotyp:Type_n_monthDay"/>
                     </xs:simpleType>
                 </xs:element>
-                <xs:element dfdl:length="4" dfdl:lengthUnits="characters" dfdl:occursCount="{/ISO8583_1987/PrimaryBitmap/Bit014}" dfdl:textNumberPadCharacter="0" ibmDfdlExtn:sampleValue="2001-12-31" minOccurs="0" name="DateExpiration_014">
+                <xs:element dfdl:length="4" dfdl:lengthUnits="characters" dfdl:occursCount="{/ISO8583_1987/PrimaryBitmap/Bit014}" dfdl:textNumberPadCharacter="0" ibmDfdlExtn:sampleValue="0112" minOccurs="0" name="DateExpiration_014">
                     <xs:simpleType>
                         <xs:restriction base="isotyp:Type_n_yearMonth"/>
                     </xs:simpleType>
                 </xs:element>
-                <xs:element dfdl:length="4" dfdl:lengthUnits="characters" dfdl:occursCount="{/ISO8583_1987/PrimaryBitmap/Bit015}" dfdl:textNumberPadCharacter="0" ibmDfdlExtn:sampleValue="2001-12-31" minOccurs="0" name="DateSettlement_015">
+                <xs:element dfdl:length="4" dfdl:lengthUnits="characters" dfdl:occursCount="{/ISO8583_1987/PrimaryBitmap/Bit015}" dfdl:textNumberPadCharacter="0" ibmDfdlExtn:sampleValue="1231" minOccurs="0" name="DateSettlement_015">
                     <xs:simpleType>
                         <xs:restriction base="isotyp:Type_n_monthDay"/>
                     </xs:simpleType>
                 </xs:element>
-                <xs:element dfdl:length="4" dfdl:lengthUnits="characters" dfdl:occursCount="{/ISO8583_1987/PrimaryBitmap/Bit016}" dfdl:textNumberPadCharacter="0" ibmDfdlExtn:sampleValue="2001-12-31" minOccurs="0" name="DateConversion_016">
+                <xs:element dfdl:length="4" dfdl:lengthUnits="characters" dfdl:occursCount="{/ISO8583_1987/PrimaryBitmap/Bit016}" dfdl:textNumberPadCharacter="0" ibmDfdlExtn:sampleValue="1231" minOccurs="0" name="DateConversion_016">
                     <xs:simpleType>
                         <xs:restriction base="isotyp:Type_n_monthDay"/>
                     </xs:simpleType>
                 </xs:element>
-                <xs:element dfdl:length="4" dfdl:lengthUnits="characters" dfdl:occursCount="{/ISO8583_1987/PrimaryBitmap/Bit017}" dfdl:textNumberPadCharacter="0" ibmDfdlExtn:sampleValue="2001-12-31" minOccurs="0" name="DateCapture_017">
+                <xs:element dfdl:length="4" dfdl:lengthUnits="characters" dfdl:occursCount="{/ISO8583_1987/PrimaryBitmap/Bit017}" dfdl:textNumberPadCharacter="0" ibmDfdlExtn:sampleValue="1231" minOccurs="0" name="DateCapture_017">
                     <xs:simpleType>
                         <xs:restriction base="isotyp:Type_n_monthDay"/>
                     </xs:simpleType>
@@ -658,9 +658,9 @@
                         </xs:restriction>
                     </xs:simpleType>
                 </xs:element>
-                <xs:element dfdl:length="6" dfdl:lengthUnits="characters" dfdl:occursCount="{xs:nonNegativeInteger(if ($isofmt:secondaryBitmapExists) then /ISO8583_1987/SecondaryBitmap/Bit073 else 0)}" dfdl:textNumberPadCharacter="0" ibmDfdlExtn:sampleValue="2001-12-31T23:59:59" minOccurs="0" name="DateAction_073">
+                <xs:element dfdl:length="6" dfdl:lengthUnits="characters" dfdl:occursCount="{xs:nonNegativeInteger(if ($isofmt:secondaryBitmapExists) then /ISO8583_1987/SecondaryBitmap/Bit073 else 0)}" dfdl:textNumberPadCharacter="0" ibmDfdlExtn:sampleValue="2001-12-31" minOccurs="0" name="DateAction_073">
                     <xs:simpleType>
-                        <xs:restriction base="isotyp:Type_n_yearMonthDay"/>
+                        <xs:restriction base="isotyp:Type_n_date"/>
                     </xs:simpleType>
                 </xs:element>
                 <xs:element dfdl:length="10" dfdl:lengthUnits="characters" dfdl:occursCount="{xs:nonNegativeInteger(if ($isofmt:secondaryBitmapExists) then /ISO8583_1987/SecondaryBitmap/Bit074 else 0)}" ibmDfdlExtn:sampleValue="1234567890" minOccurs="0" name="CreditsNumber_074">

--- a/src/ISO8583/Common/ISO8583Types.xsd
+++ b/src/ISO8583/Common/ISO8583Types.xsd
@@ -18,7 +18,7 @@
 	*
 	***********************************************************************
 	*
-	* Version 1.3 	ISO8583Types.xsd
+	* Version 1.4 	ISO8583Types.xsd
 	*
 	* This DFDL schema is for use with the IIB v10 DFDL ISO8583 tutorial.
 	*
@@ -156,11 +156,12 @@
 		<xs:restriction base="xs:decimal"/>
 	</xs:simpleType>
 	
-	<xs:simpleType name="Type_n_dateTime" dfdl:calendarPattern="MMddHHmmss" dfdl:calendarPatternKind="explicit">
-		<xs:restriction base="xs:dateTime"/>
+	<!-- Not full dateTime so use numeric string: dfdl:calendarPattern="MMddHHmmss" dfdl:calendarPatternKind="explicit" -->
+	<xs:simpleType name="Type_n_dateTimeNoYear">
+		<xs:restriction base="tns:Type_n_string"/>
 	</xs:simpleType>
 	
-	<xs:simpleType name="Type_n_yearDateTime" dfdl:calendarPattern="yyMMddHHmmss" dfdl:calendarPatternKind="explicit">
+	<xs:simpleType name="Type_n_dateTime" dfdl:calendarPattern="yyMMddHHmmss" dfdl:calendarPatternKind="explicit">
 		<xs:restriction base="xs:dateTime"/>
 	</xs:simpleType>
 	
@@ -168,15 +169,17 @@
 		<xs:restriction base="xs:time"/>
 	</xs:simpleType>
 	
-	<xs:simpleType name="Type_n_monthDay" dfdl:calendarPattern="MMdd" dfdl:calendarPatternKind="explicit">
-		<xs:restriction base="xs:date"/>
+	<!-- Not full date so use numeric string: dfdl:calendarPattern="MMdd" dfdl:calendarPatternKind="explicit" -->
+	<xs:simpleType name="Type_n_monthDay">
+		<xs:restriction base="tns:Type_n_string"/>
 	</xs:simpleType>
 	
-	<xs:simpleType name="Type_n_yearMonth" dfdl:calendarPattern="yyMM" dfdl:calendarPatternKind="explicit">
-		<xs:restriction base="xs:date"/>
+	<!-- Not full date so use numeric string: dfdl:calendarPattern="yyMM" dfdl:calendarPatternKind="explicit" -->
+	<xs:simpleType name="Type_n_yearMonth">
+		<xs:restriction base="tns:Type_n_string"/>
 	</xs:simpleType>
 	
-	<xs:simpleType name="Type_n_yearMonthDay" dfdl:calendarPattern="yyMMdd" dfdl:calendarPatternKind="explicit">
+	<xs:simpleType name="Type_n_date" dfdl:calendarPattern="yyMMdd" dfdl:calendarPatternKind="explicit">
 		<xs:restriction base="xs:date"/>
 	</xs:simpleType>
 	


### PR DESCRIPTION
Reflecting jazz107 defect 13824, which changes partial calendars from
xs:dateTime and xs:date to xs:string for correctness and performance.
